### PR TITLE
armeria updated to 0.99.9 and most part of project's tests improved:

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,7 +17,7 @@ object Vers {
     const val jfix_stdlib = "3.0.9"
 
     // Armeria
-    const val armeria = "0.99.6"
+    const val armeria = "0.99.9"
 
     // Logging
     const val log4j = "2.12.0"
@@ -67,18 +67,19 @@ object Libs {
     const val junit_api = "org.junit.jupiter:junit-jupiter-api:${Vers.junit}"
     const val junit_params = "org.junit.jupiter:junit-jupiter-params:${Vers.junit}"
     const val junit_engine = "org.junit.jupiter:junit-jupiter-engine:${Vers.junit}"
-    const val armeria_testing_junit = "com.linecorp.armeria:armeria-testing-junit:${Vers.armeria}"
+    const val armeria_junit5 = "com.linecorp.armeria:armeria-junit5:${Vers.armeria}"
     const val kotest_assertions_core_jvm = "io.kotest:kotest-assertions-core-jvm:${Vers.kotest}"
     const val mockk = "io.mockk:mockk:${Vers.mockk}"
     const val corounit_engine = "ru.fix:corounit-engine:${Vers.corounit}"
-    const val awailability_kotlin = "org.awaitility:awaitility-kotlin:${Vers.awailability}"
 }
 
 enum class Projs {
 
+    `aggregating-profiler`,
     `commons`,
-    `dynamic-request-options`,
-    `aggregating-profiler`;
+    `commons-testing`,
+    `dynamic-request`,
+    `limiter`;
 
     val dependency get(): String = ":jfix-armeria-$name"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jfix-armeria-aggregating-profiler/build.gradle.kts
+++ b/jfix-armeria-aggregating-profiler/build.gradle.kts
@@ -16,10 +16,14 @@ dependencies {
     implementation(Libs.log4j_kotlin)
 
     // Testing
+    testImplementation(project(Projs.`commons-testing`.dependency))
+    testImplementation(Libs.kotlinx_coroutines_core)
+    testImplementation(Libs.kotlinx_coroutines_jdk8)
     //   Junit
     testImplementation(Libs.junit_api)
     testImplementation(Libs.junit_params)
     testRuntimeOnly(Libs.junit_engine)
+    testRuntimeOnly(Libs.corounit_engine)
     //  Kotest
     testImplementation(Libs.kotest_assertions_core_jvm)
     //  Test Logging
@@ -27,7 +31,7 @@ dependencies {
     testRuntimeOnly(Libs.slf4j_over_log4j)
     //  Mocking
     testImplementation(Libs.mockk)
-    testImplementation(Libs.armeria_testing_junit)
+    testImplementation(Libs.armeria_junit5)
     //  JFix
     testImplementation(Libs.jfix_stdlib_socket)
 }

--- a/jfix-armeria-aggregating-profiler/src/test/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledConnectionPoolListenerTest.kt
+++ b/jfix-armeria-aggregating-profiler/src/test/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledConnectionPoolListenerTest.kt
@@ -5,108 +5,104 @@ import com.linecorp.armeria.client.ConnectionPoolListener
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.HttpResponse
 import com.linecorp.armeria.common.HttpStatus
-import com.linecorp.armeria.testing.junit.server.mock.MockWebServerExtension
 import io.kotest.assertions.assertSoftly
-import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.assertions.timing.eventually
+import io.kotest.matchers.longs.shouldBeBetween
 import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.mockk.*
+import kotlinx.coroutines.future.await
+import org.apache.logging.log4j.kotlin.Logging
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
-import ru.fix.aggregating.profiler.Identity
-import ru.fix.aggregating.profiler.IndicationProvider
-import ru.fix.aggregating.profiler.NoopProfiler
+import ru.fix.aggregating.profiler.AggregatingProfiler
 import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.EPOLL_SOCKET_CHANNEL
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.LOCAL_ADDRESS
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.LOCAL_HOST
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.localhostHttpUri
+import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.indicatorWithNameEnding
+import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.profiledCallReportWithNameEnding
+import ru.fix.armeria.commons.testing.ArmeriaMockServer
+import ru.fix.armeria.commons.testing.LocalHost
 import java.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+import kotlin.time.seconds
 
+@ExperimentalTime
 internal class ProfiledConnectionPoolListenerTest {
 
-    companion object {
+    val mockServer = ArmeriaMockServer()
 
-        @JvmField
-        @RegisterExtension
-        val mockServer = MockWebServerExtension()
+    @BeforeEach
+    suspend fun beforeEach() {
+        mockServer.start()
+    }
+
+    @AfterEach
+    suspend fun afterEach() {
+        mockServer.stop()
     }
 
     @Test
-    fun `WHEN connection created and destroyed THEN its lifetime profiled AND connections count updated`() {
-        var startTimestamp: Long? = null
-        var stopTimestamp: Long? = null
-        val connectionCountIndicatorSlot = slot<IndicationProvider>()
-        val mockedConnectionLifetimeCall = spyk(NoopProfiler.NoopProfiledCall()) {
-            every {
-                start()
-            } answers {
-                startTimestamp = System.currentTimeMillis()
-                callOriginal()
-            }
-            every {
-                stop()
-            } answers {
-                stopTimestamp = System.currentTimeMillis()
-                callOriginal()
-            }
-        }
-        val mockedProfiler = spyk(NoopProfiler()) {
-            every {
-                attachIndicator(any<String>(), capture(connectionCountIndicatorSlot))
-            } answers {
-                callOriginal()
-            }
-            excludeRecords { attachIndicator(any<String>(), any()) }
-            every {
-                profiledCall(match<Identity> { it.name == Metrics.CONNECTION_LIFETIME })
-            } returns mockedConnectionLifetimeCall
-        }
-        val connectionTtl: Long = 500
+    suspend fun `WHEN connection created and destroyed THEN its lifetime profiled AND connections count updated`() {
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val connectionTtlMs: Long = 300
         val client = WebClient
-            .builder(mockServer.localhostHttpUri())
+            .builder(mockServer.httpUri())
             .factory(
                 ClientFactory.builder()
                     .connectionPoolListener(
-                        ProfiledConnectionPoolListener(mockedProfiler, ConnectionPoolListener.noop())
+                        ProfiledConnectionPoolListener(profiler, ConnectionPoolListener.noop())
                     )
-                    .idleTimeout(Duration.ofMillis(connectionTtl))
+                    .idleTimeout(Duration.ofMillis(connectionTtlMs))
                     .build()
             ).build()
         mockServer.enqueue(HttpResponse.of(HttpStatus.OK))
-        val connectionLifetimeMetricSlot = slot<Identity>()
 
-        val connectionsIndicatorValueBeforeClientCall = connectionCountIndicatorSlot.captured.get()
-        client.get("/").aggregate().join()
-        val connectionsIndicatorValueAfterClientCall = connectionCountIndicatorSlot.captured.get()
+        val reportBeforeClientCall = profilerReporter.buildReportAndReset()
+        client.get("/").aggregate().await()
 
-        verify {
-            mockedProfiler.profiledCall(
-                capture(connectionLifetimeMetricSlot)
-            )
-            mockedConnectionLifetimeCall.start()
-        }
-        verify(timeout = connectionTtl) {
-            mockedConnectionLifetimeCall.stop()
-        }
-        val connectionsIndicatorValueAfterTtlExpired = connectionCountIndicatorSlot.captured.get()
-        confirmVerified(mockedProfiler, mockedConnectionLifetimeCall)
         assertSoftly {
-            assertSoftly(connectionLifetimeMetricSlot.captured) {
-                name shouldBe Metrics.CONNECTION_LIFETIME
-                tags shouldContainExactly mapOf(
-                    MetricTags.REMOTE_HOST to LOCAL_HOST,
-                    MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                    MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
-                    MetricTags.PROTOCOL to "h2c",
-                    MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
-                    MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL
-                )
+            reportBeforeClientCall.indicatorWithNameEnding(Metrics.ACTIVE_CHANNELS_COUNT) shouldBe 0
+            profilerReporter.buildReportAndReset().profiledCallReportWithNameEnding(Metrics.CONNECTION_LIFETIME)
+                .should {
+                    shouldNotBeNull()
+                    it!!.identity.tags shouldContainExactly mapOf(
+                        MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
+                        MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                        MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
+                        MetricTags.PROTOCOL to "h2c",
+                        MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
+                        MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL
+                    )
+                }
+        }
+        eventually((connectionTtlMs / 2).milliseconds) {
+            profilerReporter.buildReportAndReset().indicatorWithNameEnding(Metrics.ACTIVE_CHANNELS_COUNT) shouldBe 1
+        }
+        eventually(3.seconds) {
+            /**
+             * connection destroyed and:
+             * - active_channels_count indicator decreased to 0
+             * - connection lifetime metric is profiled
+             */
+            val report = profilerReporter.buildReportAndReset()
+            logger.trace { "Report: $report" }
+            assertSoftly(report) {
+                indicatorWithNameEnding(Metrics.ACTIVE_CHANNELS_COUNT) shouldBe 0
+                profiledCallReportWithNameEnding(Metrics.CONNECTION_LIFETIME).should {
+                    shouldNotBeNull()
+
+                    it!!.latencyMax.shouldBeBetween(
+                        (connectionTtlMs * 0.75).toLong(),
+                        connectionTtlMs * 2
+                    )
+                }
             }
-            (stopTimestamp!! - startTimestamp!!) shouldBeGreaterThanOrEqual 500
-            connectionsIndicatorValueBeforeClientCall shouldBe 0
-            connectionsIndicatorValueAfterClientCall shouldBe 1
-            connectionsIndicatorValueAfterTtlExpired shouldBe 0
         }
     }
+
+    companion object: Logging
 
 }

--- a/jfix-armeria-aggregating-profiler/src/test/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClientTest.kt
+++ b/jfix-armeria-aggregating-profiler/src/test/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClientTest.kt
@@ -1,91 +1,74 @@
 package ru.fix.armeria.aggregating.profiler
 
-import com.linecorp.armeria.client.ClientOption
+import com.linecorp.armeria.client.ClientOptions
 import com.linecorp.armeria.client.Endpoint
 import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.client.WebClientBuilder
 import com.linecorp.armeria.client.endpoint.EndpointGroup
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy
-import com.linecorp.armeria.client.retry.RetryRule
 import com.linecorp.armeria.client.retry.RetryingClient
 import com.linecorp.armeria.common.*
-import com.linecorp.armeria.server.ServerBuilder
-import com.linecorp.armeria.testing.junit.server.ServerExtension
-import com.linecorp.armeria.testing.junit.server.mock.MockWebServerExtension
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.timing.eventually
 import io.kotest.inspectors.forAll
+import io.kotest.inspectors.forOne
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.mockk.*
-import org.junit.jupiter.api.*
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.runBlocking
+import org.apache.logging.log4j.kotlin.Logging
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
-import ru.fix.aggregating.profiler.Identity
-import ru.fix.aggregating.profiler.NoopProfiler
-import ru.fix.aggregating.profiler.ProfiledCall
-import ru.fix.aggregating.profiler.Profiler
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.ProfilerVerifyContext.Companion.withVerifyScope
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.mockHttpConnectCall
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.mockHttpConnectedCall
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.mockHttpErrorCall
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.mockHttpSuccessCall
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.verifyConnect
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.verifyConnected
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.verifyErrorWithProfiledLatency
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.verifyErrorWithoutLatency
-import ru.fix.armeria.aggregating.profiler.ProfiledHttpClientTest.Companion.MockVerifyUtils.verifySuccess
+import ru.fix.aggregating.profiler.AggregatingProfiler
 import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.EPOLL_SOCKET_CHANNEL
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.LOCAL_ADDRESS
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.LOCAL_HOST
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.localhostHttpUri
-import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.localhostUri
-import ru.fix.armeria.commons.unwrapUnprocessedExceptionIfNecessary
+import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.profiledCallReportWithNameEnding
+import ru.fix.armeria.aggregating.profiler.ProfilerTestUtils.profiledCallReportsWithNameEnding
+import ru.fix.armeria.commons.On503AndConnectExceptionRetryRule
+import ru.fix.armeria.commons.testing.ArmeriaMockServer
+import ru.fix.armeria.commons.testing.LocalHost
 import ru.fix.stdlib.socket.SocketChecker
-import java.net.ConnectException
 import java.net.URI
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.stream.Stream
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 
-@TestInstance(TestInstance.Lifecycle.PER_METHOD)
-@Execution(ExecutionMode.CONCURRENT)
+@ExperimentalTime
 internal class ProfiledHttpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(ProtocolSpecificTest.CaseArgumentsProvider::class)
     fun `success request profiled with connect, connected and whole request flow metrics`(
         testCaseArguments: ProtocolSpecificTest.CaseArguments
-    ) {
+    ) = runBlocking<Unit> {
         val pathDelayedOk = "/ok-delayed/{delay}"
-        val mockServer = object : MockWebServerExtension() {
-            override fun configureServer(sb: ServerBuilder) {
-                sb.service(pathDelayedOk) { ctx, _ ->
-                    val delayMs = ctx.pathParam("delay")!!.toLong()
-                    HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(delayMs))
-                }
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val mockServer = ArmeriaMockServer {
+            service(pathDelayedOk) { ctx, _ ->
+                val delayMs = ctx.pathParam("delay")!!.toLong()
+                HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(delayMs))
             }
         }
         mockServer.start()
-        mockServer.server().use {
-
-            val mockedProfiler = spyk(NoopProfiler())
-            val (mockedConnectCall, mockedConnectedCall, mockedSuccessCall) = Triple(
-                mockedProfiler.mockHttpConnectCall(),
-                mockedProfiler.mockHttpConnectedCall(),
-                mockedProfiler.mockHttpSuccessCall()
-            )
-            val localhostUri = mockServer.localhostUri(SessionProtocol.find(testCaseArguments.clientProtocol)!!)
+        try {
+            val mockServerUri = mockServer.uri(SessionProtocol.find(testCaseArguments.clientProtocol)!!)
             val client = WebClient
-                .builder(localhostUri)
-                .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
+                .builder(mockServerUri)
+                .decorator(ProfiledHttpClient.newDecorator(profiler))
                 .build()
             val path = pathDelayedOk.replace("{delay}", 1_000.toString())
             val expectedConnectMetricTags = mapOf(
@@ -95,8 +78,8 @@ internal class ProfiledHttpClientTest {
                 MetricTags.IS_MULTIPLEX_PROTOCOL to testCaseArguments.connectMetricTagIsMultiplex.toString()
             )
             val expectedConnectedMetricTags = expectedConnectMetricTags + mapOf(
-                MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                MetricTags.REMOTE_HOST to LOCAL_HOST,
+                MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                 MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
                 //protocol and channel information are determined on this phase
                 MetricTags.PROTOCOL to testCaseArguments.otherMetricsTagProtocol,
@@ -105,70 +88,55 @@ internal class ProfiledHttpClientTest {
             )
             val expectedSuccessMetricTags = expectedConnectedMetricTags + (MetricTags.RESPONSE_STATUS to "200")
 
-            client.get(path).aggregate().join()
+            client.get(path).aggregate().await()
 
-            val profilerCapturer = MockVerifyUtils.ProfilerInvader()
-            verifySequence {
-                //profile connect without chosen endpoint
-                withVerifyScope(mockedProfiler to mockedConnectCall) verifyConnect {
-                    capture(profilerCapturer.connectSlot)
-                }
+            eventually(1.seconds) {
+                assertSoftly(profilerReporter.buildReportAndReset()) {
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) should {
+                        it.shouldNotBeNull()
 
-                //profile when connection established
-                withVerifyScope(mockedProfiler to mockedConnectedCall) verifyConnected {
-                    capture(profilerCapturer.connectedSlot)
-                }
+                        it.identity.tags shouldContainExactly expectedConnectMetricTags
+                    }
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) should {
+                        it.shouldNotBeNull()
 
-                //profile whole request execution
-                withVerifyScope(mockedProfiler to mockedSuccessCall) verifySuccess {
-                    capture(profilerCapturer.successSlot)
+                        it.identity.tags shouldContainExactly expectedConnectedMetricTags
+                    }
+                    profiledCallReportWithNameEnding(Metrics.HTTP_SUCCESS) should {
+                        it.shouldNotBeNull()
+
+                        it.identity.tags shouldContainExactly expectedSuccessMetricTags
+                    }
                 }
             }
-            assertSoftly(profilerCapturer) {
-                assertSoftly(connectSlot.captured) {
-                    name shouldBe Metrics.HTTP_CONNECT
-                    tags shouldContainExactly expectedConnectMetricTags
-                }
-                assertSoftly(connectedSlot.captured) {
-                    name shouldBe Metrics.HTTP_CONNECTED
-                    tags shouldContainExactly expectedConnectedMetricTags
-                }
-                assertSoftly(successSlot.captured) {
-                    name shouldBe Metrics.HTTP_SUCCESS
-                    tags shouldContainExactly expectedSuccessMetricTags
-                }
-            }
+        } finally {
+            mockServer.stop()
         }
     }
 
 
-    @Nested
-    inner class `Http (and not only) errors` {
-
-        @TestFactory
-        fun `WHEN error occured THEN it is profiled with corresponding status`() = DynamicTest.stream(
+    @TestFactory
+    fun `http (and not only) error WHEN error occured THEN it is profiled with corresponding status`() =
+        DynamicTest.stream(
 
             listOf(
 
                 ErrorProfilingTest.Case(
                     testCaseName = "Invalid (non 2xx) status 404",
                     mockServerGenerator = {
-                        val mockServer = object : ServerExtension() {
-                            override fun configure(sb: ServerBuilder) {
-                                sb.service("/some-other-path") { _, _ -> HttpResponse.of(HttpStatus.OK) }
-                            }
-
+                        val mockServer = ArmeriaMockServer {
+                            service("/some-other-path") { _, _ -> HttpResponse.of(HttpStatus.OK) }
                         }
                         mockServer.start()
-                        ErrorProfilingTest.Case.MockServer(mockServer.localhostHttpUri()) {
-                            mockServer.stop().join()
+                        ErrorProfilingTest.Case.MockServer(mockServer.httpUri()) {
+                            mockServer.stop()
                         }
                     },
                     expectedErrorMetricTagsByMockUriGenerator = {
                         listOf(
                             MetricTags.ERROR_TYPE to "invalid_status",
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to it.port.toString(),
                             MetricTags.PATH to ErrorProfilingTest.TEST_PATH,
                             MetricTags.METHOD to "GET",
@@ -184,24 +152,22 @@ internal class ProfiledHttpClientTest {
                 ErrorProfilingTest.Case(
                     testCaseName = "Invalid (non 2xx) status 500",
                     mockServerGenerator = {
-                        val mockServer = object : ServerExtension() {
-                            override fun configure(sb: ServerBuilder) {
-                                sb.service(ErrorProfilingTest.TEST_PATH) { _, _ ->
-                                    HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)
-                                }
+                        val mockServer = ArmeriaMockServer {
+                            service(ErrorProfilingTest.TEST_PATH) { _, _ ->
+                                HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)
                             }
 
                         }
                         mockServer.start()
-                        ErrorProfilingTest.Case.MockServer(mockServer.localhostHttpUri()) {
-                            mockServer.stop().join()
+                        ErrorProfilingTest.Case.MockServer(mockServer.httpUri()) {
+                            mockServer.stop()
                         }
                     },
                     expectedErrorMetricTagsByMockUriGenerator = {
                         listOf(
                             MetricTags.ERROR_TYPE to "invalid_status",
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to it.port.toString(),
                             MetricTags.PATH to ErrorProfilingTest.TEST_PATH,
                             MetricTags.METHOD to "GET",
@@ -218,7 +184,9 @@ internal class ProfiledHttpClientTest {
                     testCaseName = "Connection refused",
                     mockServerGenerator = {
                         //non-existing address
-                        ErrorProfilingTest.Case.MockServer(URI.create("http://$LOCAL_HOST:${getAvailableRandomPort()}")) {}
+                        ErrorProfilingTest.Case.MockServer(
+                            URI.create("http://${LocalHost.HOSTNAME.value}:${getAvailableRandomPort()}")
+                        ) {}
                     },
                     expectedErrorMetricTagsByMockUriGenerator = {
                         listOf(
@@ -235,19 +203,21 @@ internal class ProfiledHttpClientTest {
                 ErrorProfilingTest.Case(
                     testCaseName = "Response timeout",
                     mockServerGenerator = {
-                        val server = MockWebServerExtension().apply {
-                            start()
-                            enqueue(HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofSeconds(2)))
+                        val mockServer = ArmeriaMockServer {
+                            service(ErrorProfilingTest.TEST_PATH) { _, _ ->
+                                HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofSeconds(2))
+                            }
                         }
+                        mockServer.start()
 
-                        ErrorProfilingTest.Case.MockServer(server.localhostHttpUri()) {
-                            server.stop()
+                        ErrorProfilingTest.Case.MockServer(mockServer.httpUri()) {
+                            mockServer.stop()
                         }
                     },
                     expectedErrorMetricTagsByMockUriGenerator = {
                         listOf(
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to it.port.toString(),
                             MetricTags.ERROR_TYPE to "response_timeout",
                             MetricTags.PATH to ErrorProfilingTest.TEST_PATH,
@@ -258,21 +228,19 @@ internal class ProfiledHttpClientTest {
                         )
                     },
                     clientBuilderCustomizer = {
-                        option(ClientOption.RESPONSE_TIMEOUT_MILLIS, 500)
+                        option(ClientOptions.RESPONSE_TIMEOUT_MILLIS, 500)
                     }
                 ),
 
                 *listOf(
                     ErrorProfilingTest.ProtocolSpecificCase(
                         protocol = SessionProtocol.H1C,
-                        caseName = """Session closed of "http/1 - cleartext" request 
-                                |due to server side response timeout""".trimMargin(),
+                        caseName = """Session closed of "http/1 - cleartext" request due to server side response timeout""",
                         profiledErrorType = "response_closed_session"
                     ),
                     ErrorProfilingTest.ProtocolSpecificCase(
                         protocol = SessionProtocol.H2C,
-                        caseName = """Stream closed of "http/2 - cleartext" request 
-                                |due to server side response timeout""".trimMargin(),
+                        caseName = """Stream closed of "http/2 - cleartext" request due to server side response timeout""",
                         profiledErrorType = "response_closed_stream"
                     )
                 ).map { protocolSpecificCase ->
@@ -288,14 +256,14 @@ internal class ProfiledHttpClientTest {
                             ).apply {
                                 start()
                             }
-                            ErrorProfilingTest.Case.MockServer(server.localhostUri(protocolSpecificCase.protocol)) {
+                            ErrorProfilingTest.Case.MockServer(server.uri(protocolSpecificCase.protocol)) {
                                 server.stop()
                             }
                         },
                         expectedErrorMetricTagsByMockUriGenerator = {
                             listOf(
-                                MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                                MetricTags.REMOTE_HOST to LOCAL_HOST,
+                                MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                                MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                                 MetricTags.REMOTE_PORT to it.port.toString(),
                                 MetricTags.ERROR_TYPE to protocolSpecificCase.profiledErrorType,
                                 MetricTags.PATH to ErrorProfilingTest.TEST_PATH,
@@ -312,462 +280,438 @@ internal class ProfiledHttpClientTest {
             ).iterator(),
 
             { it.testCaseName }
-        ) { (_, setupMockForError: () -> ErrorProfilingTest.Case.MockServer,
-                expectedErrorMetricTags: (URI) -> List<MetricTag>,
+        ) { (_, setupMockForError: suspend () -> ErrorProfilingTest.Case.MockServer,
+                getExpectedErrorMetricTags: (URI) -> List<MetricTag>,
                 latencyMetricRequired: Boolean,
                 webClientBuilderCustomizer: WebClientBuilder.() -> WebClientBuilder) ->
+            runBlocking<Unit> {
 
-            setupMockForError().use { mockServer ->
-                val mockedProfiler = spyk(NoopProfiler()) {
-                    excludeRecords { //connect and connected metrics are checked by other tests
-                        profiledCall(match<Identity> { it.name in setOf(Metrics.HTTP_CONNECT, Metrics.HTTP_CONNECTED) })
-                    }
-                }
-                val mockedErrorCall = mockedProfiler.mockHttpErrorCall()
+                val profiler = AggregatingProfiler()
+                val profilerReporter = profiler.createReporter()
+                val mockServer = setupMockForError()
                 val client = WebClient.builder(mockServer.mockUri)
-                    .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
+                    .decorator(ProfiledHttpClient.newDecorator(profiler))
                     .webClientBuilderCustomizer()
                     .build()
+                val expectedErrorMetricTags = getExpectedErrorMetricTags(mockServer.mockUri).toMap()
 
                 try {
-                    client.get(ErrorProfilingTest.TEST_PATH).aggregate().join()
+                    client.get(ErrorProfilingTest.TEST_PATH).aggregate().await()
                 } catch (e: Exception) {
-                    //ignored
+                    logger.error(e)
                 }
 
-                val identitySlot = slot<Identity>()
-                verifySequence {
-                    withVerifyScope(mockedProfiler to mockedErrorCall) {
-                        if (latencyMetricRequired) {
-                            verifyErrorWithProfiledLatency {
-                                capture(identitySlot)
-                            }
-                        } else {
-                            verifyErrorWithoutLatency {
-                                capture(identitySlot)
+                eventually(1.seconds) {
+                    assertSoftly(profilerReporter.buildReportAndReset()) {
+                        profiledCallReportWithNameEnding(Metrics.HTTP_ERROR) should {
+                            it.shouldNotBeNull()
+
+                            it.identity.tags shouldContainExactly expectedErrorMetricTags
+                            if (latencyMetricRequired) {
+                                it.latencyMax shouldBeGreaterThan 0
+                            } else {
+                                it.latencyMax shouldBe 0
                             }
                         }
                     }
                 }
-                assertSoftly(identitySlot.captured) {
-                    name shouldBe Metrics.HTTP_ERROR
-                    tags shouldContainExactly expectedErrorMetricTags(mockServer.mockUri).toMap()
-                }
             }
         }
 
-        @Test
-        fun `WHEN connection unsuccessful THEN connected metric is not occured`() {
-            val mockedProfiler = spyk(NoopProfiler()) {
-                excludeRecords {
-                    profiledCall(match<Identity> { it.name in setOf(Metrics.HTTP_CONNECT, Metrics.HTTP_ERROR) })
-                }
-            }
-            val client = WebClient
-                .builder(SessionProtocol.HTTP, Endpoint.of(LOCAL_HOST, getAvailableRandomPort()))
-                .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
-                .build()
+    @Test
+    suspend fun `http (and not only) error WHEN connection unsuccessful THEN connected metric is not occured`() {
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val client = WebClient
+            .builder(SessionProtocol.HTTP, Endpoint.of(LocalHost.HOSTNAME.value, getAvailableRandomPort()))
+            .decorator(ProfiledHttpClient.newDecorator(profiler))
+            .build()
 
-            try {
-                client.get("/").aggregate().join()
-            } catch (e: Exception) {
-            }
-
-            verify { mockedProfiler wasNot Called }
-            confirmVerified(mockedProfiler)
+        try {
+            client.get("/").aggregate().await()
+        } catch (e: Exception) {
+            logger.error(e)
         }
 
-        @Test
-        fun `WHEN endpoint group is empty THEN error profiled`() {
-            val testPath = "/test-no-endpoint-group-error"
-            val profiler: Profiler = spyk(NoopProfiler()) {
-                excludeRecords {
-                    profiledCall(match<Identity> { it.name == Metrics.HTTP_CONNECT })
-                    profiledCall(match<Identity> { it.name == Metrics.HTTP_CONNECTED })
-                }
-            }
-            val mockedErrorCall = profiler.mockHttpErrorCall()
-            val client = WebClient.builder(SessionProtocol.HTTP, EndpointGroup.empty())
-                .decorator(ProfiledHttpClient.newDecorator(profiler))
-                .build()
-
-            try {
-                client.get(testPath).aggregate().join()
-            } catch (e: Exception) {
-                //ignored
-            }
-
-            val identitySlot = slot<Identity>()
-            verifySequence {
-                withVerifyScope(profiler to mockedErrorCall) verifyErrorWithoutLatency {
-                    capture(identitySlot)
-                }
-            }
-            assertSoftly(identitySlot.captured) {
-                name shouldBe Metrics.HTTP_ERROR
-                tags shouldContainExactly mapOf(
-                    MetricTags.ERROR_TYPE to "no_available_endpoint",
-                    MetricTags.PATH to testPath,
-                    MetricTags.METHOD to "GET",
-                    MetricTags.PROTOCOL to "http",
-                    MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString()
-                )
+        eventually(1.seconds) {
+            assertSoftly(profilerReporter.buildReportAndReset()) {
+                profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) shouldNotBe null
+                profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) shouldBe null
+                profiledCallReportWithNameEnding(Metrics.HTTP_ERROR) shouldNotBe null
             }
         }
-
     }
 
-    @Nested
-    inner class `WHEN retry decorator placed` {
+    @Test
+    suspend fun `http (and not only) error WHEN endpoint group is empty THEN error profiled`() {
+        val testPath = "/test-no-endpoint-group-error"
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val client = WebClient.builder(SessionProtocol.HTTP, EndpointGroup.of())
+            .decorator(ProfiledHttpClient.newDecorator(profiler))
+            .build()
 
-        @Test
-        fun `before profiled one THEN each retry attempt profiled`() {
-            val mockServer = MockWebServerExtension().apply {
-                start()
-            }
-            mockServer.server().use {
-                val mockedProfiler = spyk(NoopProfiler())
-                val expectedMetricsCount = 8
-                mockServer.enqueue(
-                    HttpResponse.delayed(
-                        HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
-                        Duration.ofMillis(500)
-                    )
-                )
-                mockServer.enqueue(
-                    HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(200))
-                )
-                val retryRule = RetryRule.onStatus(HttpStatus.SERVICE_UNAVAILABLE)
-                    .orElse(RetryRule.onException { it.unwrapUnprocessedExceptionIfNecessary() is ConnectException })
-                val client = WebClient
-                    .builder(
-                        SessionProtocol.HTTP,
-                        EndpointGroup.of(
-                            EndpointSelectionStrategy.roundRobin(),
-                            Endpoint.of(LOCAL_HOST, mockServer.httpPort()),
-                            Endpoint.of(LOCAL_HOST, getAvailableRandomPort())
-                        )
-                    )
-                    .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
-                    .decorator(RetryingClient.newDecorator(retryRule, 3))
-                    .build()
+        try {
+            client.get(testPath).aggregate().await()
+        } catch (e: Exception) {
+            logger.error(e)
+        }
 
-                client.get("/").aggregate().join()
+        eventually(1.seconds) {
+            assertSoftly(profilerReporter.buildReportAndReset()) {
+                profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) should {
+                    it.shouldNotBeNull()
 
-                val capturedProfilerIdentities = mutableListOf<Identity>()
-                verify(exactly = expectedMetricsCount) {
-                    mockedProfiler.profiledCall(
-                        capture(capturedProfilerIdentities)
+                    it.stopSum shouldBe 1
+                }
+                profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) shouldBe null
+                profiledCallReportWithNameEnding(Metrics.HTTP_ERROR) should {
+                    it.shouldNotBeNull()
+
+                    it.latencyMax shouldBe 0
+                    it.identity.tags shouldContainExactly mapOf(
+                        MetricTags.ERROR_TYPE to "no_available_endpoint",
+                        MetricTags.PATH to testPath,
+                        MetricTags.METHOD to "GET",
+                        MetricTags.PROTOCOL to "http",
+                        MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString()
                     )
                 }
-                confirmVerified(mockedProfiler)
-                capturedProfilerIdentities shouldHaveSize expectedMetricsCount
-                assertSoftly {
-                    val secondRequestIndex = 3
-                    val thirdRequestIndex = 5
-                    listOf(
-                        capturedProfilerIdentities.first(), //1st metric of 1st request
-                        capturedProfilerIdentities[secondRequestIndex], //1st metric of 2nd request
-                        capturedProfilerIdentities[thirdRequestIndex] //1st metric of 3rd request
-                    ).forAll {
-                        it.name shouldBe Metrics.HTTP_CONNECT
-                        it.tags shouldContainExactly mapOf(
+            }
+        }
+    }
+
+    @Test
+    suspend fun `WHEN retry decorator placed before profiled one THEN each retry attempt profiled`() {
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val mockServer = ArmeriaMockServer().start()
+        try {
+            mockServer.enqueue(
+                HttpResponse.delayed(
+                    HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
+                    Duration.ofMillis(500)
+                )
+            )
+            mockServer.enqueue(
+                HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(200))
+            )
+            val client = WebClient
+                .builder(
+                    SessionProtocol.HTTP,
+                    EndpointGroup.of(
+                        EndpointSelectionStrategy.roundRobin(),
+                        mockServer.httpEndpoint(),
+                        Endpoint.of(LocalHost.HOSTNAME.value, getAvailableRandomPort())
+                    )
+                )
+                .decorator(ProfiledHttpClient.newDecorator(profiler))
+                .decorator(RetryingClient.newDecorator(On503AndConnectExceptionRetryRule, 3))
+                .build()
+
+            client.get("/").aggregate().await()
+
+            eventually(1.seconds) {
+                profilerReporter.buildReportAndReset { metric, _ -> metric.name == Metrics.HTTP_CONNECT } should { report ->
+                    logger.trace { "Report: $report" }
+                    report.profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 3
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "http",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString()
                         )
                     }
-                    // Requests to valid mock server
-                    listOf(
-                        capturedProfilerIdentities[1], //2nd metric of 1st request
-                        capturedProfilerIdentities[thirdRequestIndex + 1] //2nd metric of 3rd request
-                    ).forAll {
-                        it.name shouldBe Metrics.HTTP_CONNECTED
-                        it.tags shouldContainExactly mapOf(
+                }
+            }
+            eventually(1.seconds) {
+                profilerReporter.buildReportAndReset { metric, _ -> metric.name == Metrics.HTTP_CONNECTED } should { report ->
+                    logger.trace { "Report: $report" }
+                    report.profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) should {
+                        it.shouldNotBeNull()
+                        assertSoftly {
+                            it.stopSum shouldBe 2
+                            it.identity.tags shouldContainExactly mapOf(
+                                MetricTags.PATH to "/",
+                                MetricTags.METHOD to "GET",
+                                MetricTags.PROTOCOL to "h2c",
+                                MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
+                                MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
+                                MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                                MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
+                                MetricTags.REMOTE_PORT to mockServer.httpPort().toString()
+                            )
+                        }
+                    }
+                }
+            }
+            eventually(1.seconds) {
+                profilerReporter.buildReportAndReset { metric, _ -> metric.name == Metrics.HTTP_ERROR } should { report ->
+                    logger.trace { "Report: $report" }
+                    report.profiledCallReportsWithNameEnding(Metrics.HTTP_ERROR) should { errorCallsReports ->
+                        errorCallsReports.shouldHaveSize(2)
+
+                        errorCallsReports.forAll {
+                            it.stopSum shouldBe 1
+                        }
+                        errorCallsReports.forOne {
+                            it.identity.tags shouldContainExactly mapOf(
+                                MetricTags.PATH to "/",
+                                MetricTags.METHOD to "GET",
+                                MetricTags.PROTOCOL to "http",
+                                MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString(),
+                                MetricTags.ERROR_TYPE to "connect_refused"
+                            )
+                        }
+                        errorCallsReports.forOne {
+                            it.identity.tags shouldContainExactly mapOf(
+                                MetricTags.PATH to "/",
+                                MetricTags.METHOD to "GET",
+                                MetricTags.PROTOCOL to "h2c",
+                                MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
+                                MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
+                                MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                                MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
+                                MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
+                                MetricTags.ERROR_TYPE to "invalid_status",
+                                MetricTags.RESPONSE_STATUS to "503"
+                            )
+                        }
+                    }
+                }
+            }
+            eventually(1.seconds) {
+                profilerReporter.buildReportAndReset { metric, _ -> metric.name == Metrics.HTTP_SUCCESS } should { report ->
+                    logger.trace { "Report: $report" }
+                    report.profiledCallReportWithNameEnding(Metrics.HTTP_SUCCESS) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "h2c",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
                             MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
-                            MetricTags.REMOTE_PORT to mockServer.httpPort().toString()
-                        )
-                    }
-                    //error metric of 1st requests
-                    capturedProfilerIdentities[2] should {
-                        it.name shouldBe Metrics.HTTP_ERROR
-                        it.tags shouldContainExactly mapOf(
-                            MetricTags.PATH to "/",
-                            MetricTags.METHOD to "GET",
-                            MetricTags.PROTOCOL to "h2c",
-                            MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
-                            MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
-                            MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
-                            MetricTags.ERROR_TYPE to "invalid_status",
-                            MetricTags.RESPONSE_STATUS to "503"
-                        )
-                    }
-                    //error metric of 2nd requests
-                    capturedProfilerIdentities[secondRequestIndex + 1] should {
-                        it.name shouldBe Metrics.HTTP_ERROR
-                        it.tags shouldContainExactly mapOf(
-                            MetricTags.PATH to "/",
-                            MetricTags.METHOD to "GET",
-                            MetricTags.PROTOCOL to "http",
-                            MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString(),
-                            MetricTags.ERROR_TYPE to "connect_refused"
-                        )
-                    }
-                    capturedProfilerIdentities.last() should {
-                        it.name shouldBe Metrics.HTTP_SUCCESS
-                        it.tags shouldContainExactly mapOf(
-                            MetricTags.PATH to "/",
-                            MetricTags.METHOD to "GET",
-                            MetricTags.PROTOCOL to "h2c",
-                            MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
-                            MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to mockServer.httpPort().toString(),
                             MetricTags.RESPONSE_STATUS to "200"
                         )
                     }
                 }
             }
+        } finally {
+            mockServer.stop()
         }
+    }
 
-        @Test
-        fun `after profiled one AND attempts are not exceeded THEN all retries profiled as one success request`() {
-            val mockedSuccessCall = spyk(NoopProfiler.NoopProfiledCall())
-            val mockedProfiler = spyk(NoopProfiler()) {
-                every {
-                    profiledCall(match<Identity> { it.name == Metrics.HTTP_SUCCESS })
-                } returns mockedSuccessCall
-            }
-            val expectedMetricsCount = 3
-            val mockServer = MockWebServerExtension()
-            val mockServer2 = MockWebServerExtension()
-            val firstRequestDelayMillis: Long = 500
-            val lastRequestDelayMillis: Long = 200
-            try {
-                mockServer.start()
-                mockServer2.start()
-
-                mockServer.enqueue(
-                    HttpResponse.delayed(
-                        HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
-                        Duration.ofMillis(firstRequestDelayMillis)
+    @Test
+    suspend fun `WHEN retry decorator placed after profiled one AND attempts are not exceeded THEN all retries profiled as one success request`() {
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val firstRequestDelayMillis: Long = 500
+        val lastRequestDelayMillis: Long = 200
+        val (mockServer, mockServer2) = ArmeriaMockServer() to ArmeriaMockServer()
+        try {
+            listOf(
+                mockServer.launchStart(),
+                mockServer2.launchStart()
+            ).joinAll()
+            mockServer.enqueue(
+                HttpResponse.delayed(
+                    HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
+                    Duration.ofMillis(firstRequestDelayMillis)
+                )
+            )
+            mockServer2.enqueue(
+                HttpResponse.delayed(
+                    HttpResponse.of(HttpStatus.OK), Duration.ofMillis(lastRequestDelayMillis)
+                )
+            )
+            val client = WebClient
+                .builder(
+                    SessionProtocol.HTTP,
+                    EndpointGroup.of(
+                        EndpointSelectionStrategy.roundRobin(),
+                        mockServer.httpEndpoint(),
+                        Endpoint.of(LocalHost.HOSTNAME.value, getAvailableRandomPort()),
+                        mockServer2.httpEndpoint()
                     )
                 )
-                mockServer2.enqueue(
-                    HttpResponse.delayed(HttpResponse.of(HttpStatus.OK), Duration.ofMillis(lastRequestDelayMillis))
-                )
-                val retryRule = RetryRule.onStatus(HttpStatus.SERVICE_UNAVAILABLE)
-                    .orElse(RetryRule.onException { it.unwrapUnprocessedExceptionIfNecessary() is ConnectException })
-                val client = WebClient
-                    .builder(
-                        SessionProtocol.HTTP,
-                        EndpointGroup.of(
-                            EndpointSelectionStrategy.roundRobin(),
-                            Endpoint.of(LOCAL_HOST, mockServer.httpPort()),
-                            Endpoint.of(LOCAL_HOST, getAvailableRandomPort()),
-                            Endpoint.of(LOCAL_HOST, mockServer2.httpPort())
-                        )
-                    )
-                    .decorator(RetryingClient.newDecorator(retryRule, 3))
-                    .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
-                    .build()
-                /*
-                TODO
-                 due to details of context logs when retries are present (see ProfiledHttpClient implementation),
-                 first endpoint's data is written to metrics. It would be better to fix it or reorganize structure of
-                 metrics for whole request flow processing.
-                 */
-                val expectedProfiledMockServer = mockServer/*2*/
+                .decorator(RetryingClient.newDecorator(On503AndConnectExceptionRetryRule, 3))
+                .decorator(ProfiledHttpClient.newDecorator(profiler))
+                .build()
+            /*
+            TODO
+             due to details of context logs when retries are present (see ProfiledHttpClient implementation),
+             first endpoint's data is written to metrics. It would be better to fix it or reorganize structure of
+             metrics for whole request flow processing.
+             */
+            val expectedProfiledMockServer = mockServer/*2*/
 
-                client.get("/").aggregate().join()
-                val requestEndTimestamp = System.currentTimeMillis()
+            client.get("/").aggregate().await()
 
-                val capturedProfilerIdentities = mutableListOf<Identity>()
-                val successCallSlot = slot<Long>()
-                verify(exactly = expectedMetricsCount) {
-                    mockedProfiler.profiledCall(
-                        capture(capturedProfilerIdentities)
-                    )
-                }
-                verify {
-                    mockedSuccessCall.call(
-                        capture(successCallSlot)
-                    )
-                }
-                confirmVerified(mockedProfiler, mockedSuccessCall)
-                capturedProfilerIdentities shouldHaveSize expectedMetricsCount
-                assertSoftly {
-                    capturedProfilerIdentities.first() should {
-                        it.name shouldBe Metrics.HTTP_CONNECT
-                        it.tags shouldContainExactly mapOf(
+            eventually(1.seconds) {
+                assertSoftly(profilerReporter.buildReportAndReset()) {
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "http",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString()
                         )
                     }
-                    capturedProfilerIdentities[1] should {
-                        it.name shouldBe Metrics.HTTP_CONNECTED
-                        it.tags shouldContainExactly mapOf(
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "h2c",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
                             MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to expectedProfiledMockServer.httpPort().toString()
                         )
                     }
-                    capturedProfilerIdentities.last() should {
-                        it.name shouldBe Metrics.HTTP_SUCCESS
-                        it.tags shouldContainExactly mapOf(
+                    profiledCallReportWithNameEnding(Metrics.HTTP_SUCCESS) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "h2c",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
                             MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to expectedProfiledMockServer.httpPort().toString(),
                             MetricTags.RESPONSE_STATUS to "200"
                         )
+                        it.latencyMax shouldBeGreaterThan firstRequestDelayMillis + lastRequestDelayMillis
                     }
-                    (requestEndTimestamp - successCallSlot.captured) shouldBeGreaterThan
-                            firstRequestDelayMillis + lastRequestDelayMillis
                 }
-            } finally {
-                mockServer.stop()
-                mockServer2.stop()
             }
+
+        } finally {
+            listOf(
+                mockServer.launchStop(),
+                mockServer2.launchStop()
+            ).joinAll()
         }
+    }
 
-        @Test
-        fun `after profiled one AND attempts are exceeded THEN all retries profiled as one error request`() {
-            val mockedErrorCall = spyk(NoopProfiler.NoopProfiledCall())
-            val mockedProfiler = spyk(NoopProfiler()) {
-                every {
-                    profiledCall(match<Identity> { it.name == Metrics.HTTP_ERROR })
-                } returns mockedErrorCall
-            }
-            val expectedMetricsCount = 3
-            val mockServer = MockWebServerExtension()
-            val mockServer2 = MockWebServerExtension()
-            val firstRequestDelayMillis: Long = 400
-            val lastRequestDelayMillis: Long = 300
-            try {
-                mockServer.start()
-                mockServer2.start()
-
-                mockServer.enqueue(
-                    HttpResponse.delayed(
-                        HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
-                        Duration.ofMillis(firstRequestDelayMillis)
+    @Test
+    suspend fun `WHEN retry decorator placed after profiled one AND attempts are exceeded THEN all retries profiled as one error request`() {
+        val profiler = AggregatingProfiler()
+        val profilerReporter = profiler.createReporter()
+        val firstRequestDelayMillis: Long = 400
+        val lastRequestDelayMillis: Long = 300
+        val (mockServer, mockServer2) = ArmeriaMockServer() to ArmeriaMockServer()
+        try {
+            listOf(
+                mockServer.launchStart(),
+                mockServer2.launchStart()
+            ).joinAll()
+            mockServer.enqueue(
+                HttpResponse.delayed(
+                    HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
+                    Duration.ofMillis(firstRequestDelayMillis)
+                )
+            )
+            mockServer2.enqueue(
+                HttpResponse.delayed(
+                    HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
+                    Duration.ofMillis(lastRequestDelayMillis)
+                )
+            )
+            val client = WebClient
+                .builder(
+                    SessionProtocol.HTTP,
+                    EndpointGroup.of(
+                        EndpointSelectionStrategy.roundRobin(),
+                        mockServer.httpEndpoint(),
+                        Endpoint.of(LocalHost.HOSTNAME.value, getAvailableRandomPort()),
+                        mockServer2.httpEndpoint()
                     )
                 )
-                mockServer2.enqueue(
-                    HttpResponse.delayed(
-                        HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE),
-                        Duration.ofMillis(lastRequestDelayMillis)
-                    )
-                )
-                val retryRule = RetryRule.onStatus(HttpStatus.SERVICE_UNAVAILABLE)
-                    .orElse(RetryRule.onException { it.unwrapUnprocessedExceptionIfNecessary() is ConnectException })
-                val client = WebClient
-                    .builder(
-                        SessionProtocol.HTTP,
-                        EndpointGroup.of(
-                            EndpointSelectionStrategy.roundRobin(),
-                            Endpoint.of(LOCAL_HOST, mockServer.httpPort()),
-                            Endpoint.of(LOCAL_HOST, getAvailableRandomPort()),
-                            Endpoint.of(LOCAL_HOST, mockServer2.httpPort())
-                        )
-                    )
-                    .decorator(RetryingClient.newDecorator(retryRule, 3))
-                    .decorator(ProfiledHttpClient.newDecorator(mockedProfiler))
-                    .build()
-                /*
-                TODO
-                 due to details of context logs when retries are present (see ProfiledHttpClient implementation),
-                 first endpoint's data is written to metrics. It would be better to fix it or reorganize structure of
-                 metrics for whole request flow processing.
-                 */
-                val expectedProfiledMockServer = mockServer/*2*/
+                .decorator(RetryingClient.newDecorator(On503AndConnectExceptionRetryRule, 3))
+                .decorator(ProfiledHttpClient.newDecorator(profiler))
+                .build()
+            /*
+            TODO
+             due to details of context logs when retries are present (see ProfiledHttpClient implementation),
+             first endpoint's data is written to metrics. It would be better to fix it or reorganize structure of
+             metrics for whole request flow processing.
+             */
+            val expectedProfiledMockServer = mockServer/*2*/
 
-                client.get("/").aggregate().join()
-                val requestEndTimestamp = System.currentTimeMillis()
+            client.get("/").aggregate().await()
 
-                val capturedProfilerIdentities = mutableListOf<Identity>()
-                val successCallSlot = slot<Long>()
-                verify(exactly = expectedMetricsCount) {
-                    mockedProfiler.profiledCall(
-                        capture(capturedProfilerIdentities)
-                    )
-                }
-                verify {
-                    mockedErrorCall.call(
-                        capture(successCallSlot)
-                    )
-                }
-                confirmVerified(mockedProfiler, mockedErrorCall)
-                capturedProfilerIdentities shouldHaveSize expectedMetricsCount
-                assertSoftly {
-                    capturedProfilerIdentities.first() should {
-                        it.name shouldBe Metrics.HTTP_CONNECT
-                        it.tags shouldContainExactly mapOf(
+            eventually(1.seconds) {
+                assertSoftly(profilerReporter.buildReportAndReset()) {
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECT) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "http",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to false.toString()
                         )
                     }
-                    capturedProfilerIdentities[1] should {
-                        it.name shouldBe Metrics.HTTP_CONNECTED
-                        it.tags shouldContainExactly mapOf(
+                    profiledCallReportWithNameEnding(Metrics.HTTP_CONNECTED) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "h2c",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
                             MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to expectedProfiledMockServer.httpPort().toString()
                         )
                     }
-                    capturedProfilerIdentities.last() should {
-                        it.name shouldBe Metrics.HTTP_ERROR
-                        it.tags shouldContainExactly mapOf(
+                    profiledCallReportWithNameEnding(Metrics.HTTP_ERROR) should {
+                        it.shouldNotBeNull()
+
+                        it.stopSum shouldBe 1
+                        it.identity.tags shouldContainExactly mapOf(
                             MetricTags.PATH to "/",
                             MetricTags.METHOD to "GET",
                             MetricTags.PROTOCOL to "h2c",
                             MetricTags.IS_MULTIPLEX_PROTOCOL to true.toString(),
                             MetricTags.CHANNEL_CLASS to EPOLL_SOCKET_CHANNEL,
-                            MetricTags.REMOTE_ADDRESS to LOCAL_ADDRESS,
-                            MetricTags.REMOTE_HOST to LOCAL_HOST,
+                            MetricTags.REMOTE_ADDRESS to LocalHost.IP.value,
+                            MetricTags.REMOTE_HOST to LocalHost.HOSTNAME.value,
                             MetricTags.REMOTE_PORT to expectedProfiledMockServer.httpPort().toString(),
                             MetricTags.ERROR_TYPE to "invalid_status",
                             MetricTags.RESPONSE_STATUS to "503"
                         )
+                        it.latencyMax shouldBeGreaterThan firstRequestDelayMillis + lastRequestDelayMillis
                     }
-                    (requestEndTimestamp - successCallSlot.captured) shouldBeGreaterThan
-                            firstRequestDelayMillis + lastRequestDelayMillis
                 }
-            } finally {
-                mockServer.stop()
-                mockServer2.stop()
             }
+        } finally {
+            listOf(
+                mockServer.launchStop(),
+                mockServer2.launchStop()
+            ).joinAll()
         }
-
     }
 
 /*
@@ -783,86 +727,9 @@ internal class ProfiledHttpClientTest {
 //    fun `WHEN connect timeouted THEN error profiled`() {
 //    }
 
-    companion object {
+    companion object : Logging {
 
         fun getAvailableRandomPort() = SocketChecker.getAvailableRandomPort()
-
-        object MockVerifyUtils {
-            class ProfilerInvader {
-                val connectSlot = slot<Identity>()
-                val connectedSlot = slot<Identity>()
-                val successSlot = slot<Identity>()
-            }
-
-            private fun Profiler.mockCallMatchingName(name: String) =
-                spyk(NoopProfiler.NoopProfiledCall()).also { call ->
-                    every {
-                        profiledCall(match<Identity> {
-                            it.name == name
-                        })
-                    } returns call
-                }
-
-            fun Profiler.mockHttpConnectCall(): ProfiledCall = mockCallMatchingName(Metrics.HTTP_CONNECT)
-            fun Profiler.mockHttpConnectedCall(): ProfiledCall = mockCallMatchingName(Metrics.HTTP_CONNECTED)
-            fun Profiler.mockHttpSuccessCall(): ProfiledCall = mockCallMatchingName(Metrics.HTTP_SUCCESS)
-            fun Profiler.mockHttpErrorCall(): ProfiledCall = mockCallMatchingName(Metrics.HTTP_ERROR)
-
-
-            class ProfilerVerifyContext private constructor(
-                val verificationScope: MockKVerificationScope,
-                val mockedProfiler: Profiler,
-                val mockedCall: ProfiledCall
-            ) {
-                companion object {
-                    fun MockKVerificationScope.withVerifyScope(profilerPair: Pair<Profiler, ProfiledCall>): ProfilerVerifyContext =
-                        ProfilerVerifyContext(this, profilerPair.first, profilerPair.second)
-
-                    fun MockKVerificationScope.withVerifyScope(
-                        profilerPair: Pair<Profiler, ProfiledCall>,
-                        block: ProfilerVerifyContext.() -> Unit
-                    ) {
-                        withVerifyScope(profilerPair).block()
-                    }
-                }
-
-            }
-
-            infix fun ProfilerVerifyContext.verifyConnect(capture: () -> Identity) {
-                mockedProfiler.profiledCall(capture())
-                mockedCall.start()
-                mockedCall.stop()
-            }
-
-            infix fun ProfilerVerifyContext.verifyConnected(capture: () -> Identity) {
-                mockedProfiler.profiledCall(capture())
-                mockedCall.call(verificationScope.any<Long>())
-            }
-
-            infix fun ProfilerVerifyContext.verifySuccess(capture: () -> Identity) {
-                mockedProfiler.profiledCall(capture())
-                mockedCall.call(verificationScope.any<Long>())
-            }
-
-            private fun ProfilerVerifyContext.verifyError(latencyProfiled: Boolean, capture: () -> Identity) {
-                mockedProfiler.profiledCall(capture())
-                mockedCall.run {
-                    if (latencyProfiled) {
-                        call(verificationScope.any<Long>())
-                    } else {
-                        call()
-                    }
-                }
-            }
-
-            infix fun ProfilerVerifyContext.verifyErrorWithProfiledLatency(capture: () -> Identity) {
-                verifyError(true, capture)
-            }
-
-            infix fun ProfilerVerifyContext.verifyErrorWithoutLatency(capture: () -> Identity) {
-                verifyError(false, capture)
-            }
-        }
 
     }
 
@@ -917,12 +784,10 @@ internal class ProfiledHttpClientTest {
                 fullResponseDelay: Duration,
                 responseStatus: HttpStatus,
                 numberOfResponseParts: Int
-            ): ServerExtension {
-                return object : ServerExtension() {
-                    override fun configure(sb: ServerBuilder) {
-                        sb.requestTimeout(serverRequestTimeout)
-
-                        sb.service(targetPath) { ctx, _ ->
+            ): ArmeriaMockServer {
+                return ArmeriaMockServer {
+                    this.requestTimeout(serverRequestTimeout)
+                        .service(targetPath) { ctx, _ ->
                             HttpResponse.streaming().also { response ->
                                 val responseStatusHeader = ResponseHeaders.of(responseStatus)
                                 response.write(responseStatusHeader)
@@ -944,8 +809,6 @@ internal class ProfiledHttpClientTest {
                                 }
                             }
                         }
-                    }
-
                 }
             }
 
@@ -959,7 +822,7 @@ internal class ProfiledHttpClientTest {
 
         data class Case(
             val testCaseName: String,
-            val mockServerGenerator: () -> MockServer,
+            val mockServerGenerator: suspend () -> MockServer,
             val expectedErrorMetricTagsByMockUriGenerator: (URI) -> List<MetricTag>,
             val latencyMetricRequired: Boolean = false,
             val clientBuilderCustomizer: WebClientBuilder.() -> WebClientBuilder = { this }
@@ -967,12 +830,8 @@ internal class ProfiledHttpClientTest {
 
             class MockServer(
                 val mockUri: URI,
-                private val stop: () -> Unit
-            ) : AutoCloseable {
-                override fun close() {
-                    stop()
-                }
-            }
+                val stop: suspend () -> Unit
+            )
 
         }
 

--- a/jfix-armeria-aggregating-profiler/src/test/resources/junit-platform.properties
+++ b/jfix-armeria-aggregating-profiler/src/test/resources/junit-platform.properties
@@ -1,2 +1,5 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+corounit.execution.parallelism=4

--- a/jfix-armeria-commons-testing/build.gradle.kts
+++ b/jfix-armeria-commons-testing/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    api(Libs.armeria)
+    api(Libs.armeria_junit5)
+
+    implementation(Libs.kotlin_jdk8)
+    implementation(Libs.kotlinx_coroutines_jdk8)
+}

--- a/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/ArmeriaMockServer.kt
+++ b/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/ArmeriaMockServer.kt
@@ -1,0 +1,106 @@
+package ru.fix.armeria.commons.testing
+
+import com.linecorp.armeria.client.Endpoint
+import com.linecorp.armeria.common.AggregatedHttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.SerializationFormat
+import com.linecorp.armeria.common.SessionProtocol
+import com.linecorp.armeria.common.util.EventLoopGroups
+import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.ServerBuilder
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
+import java.net.URI
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class ArmeriaMockServer(
+    mockServerName: String = "armeria-mock-server",
+    serverBuilderCustomizer: ServerBuilder.() -> ServerBuilder = { this }
+) {
+
+    private val mockResponses: ConcurrentLinkedQueue<HttpResponse> = ConcurrentLinkedQueue()
+
+    private val server = Server.builder()
+        .http(0)
+        .https(0)
+        .tlsSelfSigned()
+        .workerGroup(EventLoopGroups.newEventLoopGroup(1, "$mockServerName-eventloop-worker"), true)
+        .service("/") { _, req ->
+            HttpResponse.from(req.aggregate().thenApply {
+                mockResponses.poll()
+                    ?: throw IllegalStateException(
+                        "No mock response configured. Did you call enqueueResponse? Request: $it")
+            })
+        }
+        .serverBuilderCustomizer()
+        .build()
+
+    private val serverStarted: Boolean
+        get() = server.activePorts().isNotEmpty()
+
+    private fun serverHasSessionProtocol(protocol: SessionProtocol): Boolean =
+        server.activePorts().filterValues { it.hasProtocol(protocol) }.isNotEmpty()
+
+    suspend fun start(): ArmeriaMockServer = apply {
+        server.start().await()
+    }
+
+    fun launchStart(): Job = GlobalScope.launch { start() }
+
+    suspend fun stop(): ArmeriaMockServer = apply {
+        server.stop().await()
+    }
+
+    fun launchStop(): Job = GlobalScope.launch { stop() }
+
+    fun enqueue(httpResponse: HttpResponse) {
+        mockResponses.add(httpResponse)
+    }
+
+    fun port(protocol: SessionProtocol) = server.activeLocalPort(protocol)
+
+    fun httpPort(): Int = port(SessionProtocol.HTTP)
+
+    fun httpsPort(): Int = port(SessionProtocol.HTTPS)
+
+    fun endpoint(sessionProtocol: SessionProtocol, localHost: LocalHost = LocalHost.HOSTNAME): Endpoint =
+        Endpoint.of(localHost.value, port(sessionProtocol))
+
+    fun httpEndpoint() = endpoint(SessionProtocol.HTTP)
+
+    fun httpsEndpoint() = endpoint(SessionProtocol.HTTPS)
+
+    fun httpUri(): URI = uri(SessionProtocol.HTTP)
+
+    fun httpsUri(): URI = uri(SessionProtocol.HTTPS)
+
+    fun uri(
+        protocol: SessionProtocol,
+        localHost: LocalHost = LocalHost.HOSTNAME,
+        format: SerializationFormat = SerializationFormat.NONE
+    ): URI {
+        require(serverStarted)
+
+        val port: Int = when {
+            !protocol.isTls && serverHasSessionProtocol(SessionProtocol.HTTP) -> {
+                server.activeLocalPort(SessionProtocol.HTTP)
+            }
+            protocol.isTls && serverHasSessionProtocol(SessionProtocol.HTTPS) -> {
+                server.activeLocalPort(SessionProtocol.HTTPS)
+            }
+            else -> {
+                throw IllegalStateException("can't find the specified port")
+            }
+        }
+
+        val uriStr = "${protocol.uriText()}://${localHost.value}:$port"
+        return if (format === SerializationFormat.NONE) {
+            URI.create(uriStr)
+        } else {
+            URI.create(format.uriText() + '+' + uriStr)
+        }
+    }
+
+}

--- a/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/LocalHost.kt
+++ b/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/LocalHost.kt
@@ -1,0 +1,6 @@
+package ru.fix.armeria.commons.testing
+
+enum class LocalHost(val value: String) {
+    IP("127.0.0.1"), HOSTNAME("localhost");
+}
+

--- a/jfix-armeria-commons/src/main/kotlin/ru/fix/armeria/commons/RetryRules.kt
+++ b/jfix-armeria-commons/src/main/kotlin/ru/fix/armeria/commons/RetryRules.kt
@@ -1,0 +1,10 @@
+package ru.fix.armeria.commons
+
+import com.linecorp.armeria.client.retry.RetryRule
+import com.linecorp.armeria.common.HttpStatus
+import java.net.ConnectException
+
+val On503AndConnectExceptionRetryRule: RetryRule = RetryRule.onStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    .orElse(RetryRule.onException { _, thr ->
+        thr.unwrapUnprocessedExceptionIfNecessary() is ConnectException
+    })

--- a/jfix-armeria-dynamic-request/build.gradle.kts
+++ b/jfix-armeria-dynamic-request/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(Libs.kotlin_jdk8)
 
     // Testing
+    testImplementation(project(Projs.`commons-testing`.dependency))
     testImplementation(Libs.kotlinx_coroutines_core)
     testImplementation(Libs.kotlinx_coroutines_jdk8)
     //   Junit
@@ -27,5 +28,5 @@ dependencies {
     testRuntimeOnly(Libs.slf4j_over_log4j)
     //  Mocking
     testImplementation(Libs.mockk)
-    testImplementation(Libs.armeria_testing_junit)
+    testImplementation(Libs.armeria_junit5)
 }

--- a/jfix-armeria-dynamic-request/src/main/kotlin/ru/fix/armeria/dynamic/request/options/DynamicRequestOptionsClient.kt
+++ b/jfix-armeria-dynamic-request/src/main/kotlin/ru/fix/armeria/dynamic/request/options/DynamicRequestOptionsClient.kt
@@ -26,7 +26,7 @@ class DynamicRequestOptionsClient<RequestT : Request, ResponseT : Response>(
     override fun execute(ctx: ClientRequestContext, req: RequestT): ResponseT {
         ctx.setWriteTimeoutMillis(writeTimeoutProperty.get())
         ctx.setResponseTimeoutMillis(readTimeoutProperty.get())
-        return delegate<Client<RequestT, ResponseT>>().execute(ctx, req)
+        return unwrap().execute(ctx, req)
     }
 
     companion object {

--- a/jfix-armeria-dynamic-request/src/test/resources/junit-platform.properties
+++ b/jfix-armeria-dynamic-request/src/test/resources/junit-platform.properties
@@ -1,3 +1,5 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
 corounit.execution.parallelism=4

--- a/jfix-armeria-limiter/build.gradle.kts
+++ b/jfix-armeria-limiter/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(Libs.kotlin_jdk8)
 
     // Testing
+    testImplementation(project(Projs.`commons-testing`.dependency))
     testImplementation(Libs.kotlinx_coroutines_core)
     testImplementation(Libs.kotlinx_coroutines_jdk8)
     //   Junit
@@ -21,15 +22,14 @@ dependencies {
     //  Kotest
     testImplementation(Libs.kotest_assertions_core_jvm)
     //  Test Logging
+    testImplementation(Libs.log4j_kotlin)
     testRuntimeOnly(Libs.log4j_core)
     testRuntimeOnly(Libs.slf4j_over_log4j)
     //  Mocking
     testImplementation(Libs.mockk)
-    testImplementation(Libs.armeria_testing_junit)
+    testImplementation(Libs.armeria_junit5)
     //  JFix components
     testImplementation(Libs.jfix_stdlib_concurrency)
     //  Armeria
     testImplementation(Libs.armeria_retrofit2)
-    //  Other useful testing APIs
-    testImplementation(Libs.awailability_kotlin)
 }

--- a/jfix-armeria-limiter/src/main/kotlin/ru/fix/armeria/limiter/RateLimitingClient.kt
+++ b/jfix-armeria-limiter/src/main/kotlin/ru/fix/armeria/limiter/RateLimitingClient.kt
@@ -27,7 +27,7 @@ abstract class RateLimitingClient<RequestT : Request, ResponseT : Response>(
     override fun execute(ctx: ClientRequestContext, req: RequestT): ResponseT {
         val deferredResult = rateLimiterDispatcher.compose(
             {
-                delegate<Client<RequestT, ResponseT>>().execute(ctx, req)
+                unwrap().execute(ctx, req)
             },
             { response, asyncResultCallback ->
                 response.whenComplete().handle { _, _ -> asyncResultCallback.onAsyncResultCompleted() }

--- a/jfix-armeria-limiter/src/test/kotlin/ru/fix/armeria/limiter/ProfilerTestUtils.kt
+++ b/jfix-armeria-limiter/src/test/kotlin/ru/fix/armeria/limiter/ProfilerTestUtils.kt
@@ -1,11 +1,9 @@
-package ru.fix.armeria.aggregating.profiler
+package ru.fix.armeria.limiter
 
 import ru.fix.aggregating.profiler.ProfiledCallReport
 import ru.fix.aggregating.profiler.ProfilerReport
 
 object ProfilerTestUtils {
-
-    const val EPOLL_SOCKET_CHANNEL = "EpollSocketChannel"
 
     fun ProfilerReport.indicatorWithNameEnding(nameEnding: String): Long? =
         indicators.mapKeys { it.key.name }.toList().singleOrNull { (name, _) ->

--- a/jfix-armeria-limiter/src/test/resources/junit-platform.properties
+++ b/jfix-armeria-limiter/src/test/resources/junit-platform.properties
@@ -1,3 +1,5 @@
 junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.config.strategy=dynamic
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
 corounit.execution.parallelism=4

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "jfix-armeria"
 
 val projects = listOf(
     "commons",
+    "commons-testing",
     "dynamic-request",
     "aggregating-profiler",
     "limiter"


### PR DESCRIPTION
- separate suspendable ArmeriaMockServer created in new module commons-testing
- ProfiledHttpClientTest stabilized by using AggregatingProfiler instead of spying NoopProfiler
- all tests made parallel and all (except part of test cases of ProfiledHttpClientTest) are rewritten as suspendable corounit tests