### PR TITLE
Profiling decorator improved and fixed:

### DIFF
--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
@@ -81,15 +81,17 @@ internal fun RequestLog.detectProfiledErrorIfAny(): ProfiledError? {
                 }
             }
         }
-        responseCause != null ->
-            when (responseCause) {
+        responseCause != null -> responseCause.unwrapUnprocessedExceptionIfNecessary().let {
+            when (it) {
+                is ConnectException -> ProfiledError.ConnectRefused
                 is ResponseTimeoutException -> ProfiledError.ResponseTimeout
                 is ClosedSessionException -> ProfiledError.ResponseClosedSession
                 is ClosedStreamException -> ProfiledError.ResponseClosedStream
                 else -> {
-                    ProfiledError.UnrecognizedError.WithCause.InResponse(responseCause)
+                    ProfiledError.UnrecognizedError.WithCause.InResponse(it)
                 }
             }
+        }
         status == HttpStatus.UNKNOWN -> {
             ProfiledError.UnrecognizedError.UnknownStatus
         }

--- a/jfix-armeria-commons/src/main/kotlin/ru/fix/armeria/commons/RetryRules.kt
+++ b/jfix-armeria-commons/src/main/kotlin/ru/fix/armeria/commons/RetryRules.kt
@@ -2,9 +2,9 @@ package ru.fix.armeria.commons
 
 import com.linecorp.armeria.client.retry.RetryRule
 import com.linecorp.armeria.common.HttpStatus
-import java.net.ConnectException
 
-val On503AndConnectExceptionRetryRule: RetryRule = RetryRule.onStatus(HttpStatus.SERVICE_UNAVAILABLE)
-    .orElse(RetryRule.onException { _, thr ->
-        thr.unwrapUnprocessedExceptionIfNecessary() is ConnectException
-    })
+val On503AndUnprocessedRetryRule: RetryRule = RetryRule
+    .builder()
+    .onStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    .onUnprocessed()
+    .thenBackoff()


### PR DESCRIPTION
- now http_connect metric writes host/port tags
- connect_refused error detection fixed (when it is placed before retrying decorator