### PR TITLE
DynamicRequestOptionsClient api improved and commons-testing API extended:

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/KotlinStdLibExtensions.kt
+++ b/jfix-armeria-commons-testing/src/main/kotlin/ru/fix/armeria/commons/testing/KotlinStdLibExtensions.kt
@@ -1,0 +1,9 @@
+package ru.fix.armeria.commons.testing
+
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaDuration
+
+@ExperimentalTime
+val Duration.j: java.time.Duration
+    get() = toJavaDuration()

--- a/jfix-armeria-dynamic-request/src/test/kotlin/ru/fix/armeria/dynamic/request/options/DynamicRequestOptionsClientTest.kt
+++ b/jfix-armeria-dynamic-request/src/test/kotlin/ru/fix/armeria/dynamic/request/options/DynamicRequestOptionsClientTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.time.delay
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -47,6 +48,8 @@ internal class DynamicRequestOptionsClientTest {
         // no timeout happened
         mockServer.enqueue(delayedResponseCreator)
         val expectedToNotFailRequest = client.get("/")
+        // give request time to start befor changing property
+        delay(100.milliseconds.j)
         // change property and now timeout must take place on next request
         readTimeoutProperty.set(500.milliseconds)
         expectedToNotFailRequest.aggregate().await() should {


### PR DESCRIPTION
- DynamicRequestOptionsClient writeTimeout property is optional now
- DynamicRequestOptionsClient properties moved from long millis to Java's duration
- ArmeriaMockServer now supports getting recorded requests
- gradlew updated to 6.6.1