### PR TITLE
Skip endpoints on client build

### DIFF
--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -23,8 +23,6 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
 
     fun setClientName(clientName: String): HttpClientBuilderT
 
-    fun setIgnoreEndpoint(ignore: Boolean): HttpClientBuilderT
-
     fun setEndpoint(uri: String): HttpClientBuilderT = setEndpoint(URI.create(uri))
     fun setEndpoint(uri: URI): HttpClientBuilderT
     fun setEndpoint(host: String, port: Int): HttpClientBuilderT

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -18,7 +18,7 @@ import java.time.Duration
 interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<HttpClientBuilderT>> {
 
     /*
-     * Mandatory builder methods. Client name and endpoint/endpoint_group must be formed.
+     * Methods could be omitted. If so, default WebClient without endpoint_group/endpoint will be built
      */
 
     fun setClientName(clientName: String): HttpClientBuilderT

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -18,10 +18,14 @@ import java.time.Duration
 interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<HttpClientBuilderT>> {
 
     /*
-     * Methods could be omitted. If so, default WebClient without endpoint_group/endpoint will be built
+     * Mandatory builder method. Client name must be formed.
      */
 
     fun setClientName(clientName: String): HttpClientBuilderT
+
+    /*
+     * Methods could be omitted. If so, default WebClient without endpoint_group/endpoint will be built
+     */
 
     fun setEndpoint(uri: String): HttpClientBuilderT = setEndpoint(URI.create(uri))
     fun setEndpoint(uri: URI): HttpClientBuilderT
@@ -56,11 +60,6 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
     fun setEndpointGroup(
         endpointGroup: EndpointGroup
     ): HttpClientBuilderT
-
-    /*
-     * END Mandatory builder methods.
-     */
-
 
     fun setIoThreadsCount(count: Int): HttpClientBuilderT
 

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -23,6 +23,8 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
 
     fun setClientName(clientName: String): HttpClientBuilderT
 
+    fun setIgnoreEndpoint(ignore: Boolean): HttpClientBuilderT
+
     fun setEndpoint(uri: String): HttpClientBuilderT = setEndpoint(URI.create(uri))
     fun setEndpoint(uri: URI): HttpClientBuilderT
     fun setEndpoint(host: String, port: Int): HttpClientBuilderT


### PR DESCRIPTION
Allow buildArmeriaWebClient  to return builder with no params: WebClient.builder(), so we are not tied to endpoints or endpoint groups