### PR TITLE
Skip endpoints on client build

### DIFF
--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -18,10 +18,14 @@ import java.time.Duration
 interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<HttpClientBuilderT>> {
 
     /*
-     * Mandatory builder methods. Client name and endpoint/endpoint_group must be formed.
+     * Mandatory builder method. Client name must be formed.
      */
 
     fun setClientName(clientName: String): HttpClientBuilderT
+
+    /*
+     * Methods could be omitted. If so, default WebClient without endpoint_group/endpoint will be built
+     */
 
     fun setEndpoint(uri: String): HttpClientBuilderT = setEndpoint(URI.create(uri))
     fun setEndpoint(uri: URI): HttpClientBuilderT
@@ -56,11 +60,6 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
     fun setEndpointGroup(
         endpointGroup: EndpointGroup
     ): HttpClientBuilderT
-
-    /*
-     * END Mandatory builder methods.
-     */
-
 
     fun setIoThreadsCount(count: Int): HttpClientBuilderT
 

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
@@ -31,8 +31,8 @@ internal data class BaseHttpClientBuilderState(
         throw IllegalStateException("clientName must be set")
     },
     val sessionProtocol: SessionProtocol = SessionProtocol.HTTP,
-    val endpointGroupCreator: () -> Either<Lazy<EndpointGroup>, URI> = {
-        throw IllegalStateException("endpoint/endpoint_group or URI must be set")
+    val endpointGroupCreator: () -> Either<Lazy<EndpointGroup>, URI>? = {
+        null
     },
     val ioThreadsCount: Int? = null,
     val clientFactoryBuilder: () -> ClientFactoryBuilder = { ClientFactory.builder() },
@@ -155,6 +155,7 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
         val webClientBuilder = when (endpointGroup) {
             is Either.Left -> WebClient.builder(baseBuilderState.sessionProtocol, endpointGroup.value.value)
             is Either.Right -> WebClient.builder(endpointGroup.value)
+            else -> WebClient.builder()
         }
 
         // build ClientFactory
@@ -197,7 +198,7 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
                     }
                     logger.info { "$clientName: closing http client factory under the hood..." }
                     clientFactory.close()
-                    endpointGroup.leftOrNull?.let {
+                    endpointGroup?.leftOrNull?.let {
                         logger.info { "$clientName: closing endpoint (group)..." }
                         it.value.close()
                     }


### PR DESCRIPTION
Allow buildArmeriaWebClient to return builder with no params: WebClient.builder(), so we are not tied to endpoints or endpoint groups.