### PR TITLE
Valid response statuses codes config added

### DIFF
--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
@@ -62,12 +62,16 @@ internal sealed class ProfiledError(
     }
 }
 
+/**
+ * @param isResponseStatusValid  It is guaranteed that input [HttpStatus] is not [HttpStatus.UNKNOWN]
+ * so that if this checking function is called then http response is received
+ */
 internal fun RequestLog.detectProfiledErrorIfAny(isResponseStatusValid: (HttpStatus) -> Boolean): ProfiledError? {
     val requestCause = requestCause()
     val responseCause = responseCause()
     val status = responseHeaders().status()
     return when {
-        !isResponseStatusValid(status) && status != HttpStatus.UNKNOWN -> ProfiledError.InvalidStatus
+        status != HttpStatus.UNKNOWN && !isResponseStatusValid(status) -> ProfiledError.InvalidStatus
         requestCause != null -> requestCause.unwrapUnprocessedExceptionIfNecessary().let {
             when (it) {
                 is ConnectException -> ProfiledError.ConnectRefused

--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
@@ -5,7 +5,6 @@ import com.linecorp.armeria.client.SessionProtocolNegotiationException
 import com.linecorp.armeria.client.endpoint.EndpointGroupException
 import com.linecorp.armeria.common.ClosedSessionException
 import com.linecorp.armeria.common.HttpStatus
-import com.linecorp.armeria.common.HttpStatusClass
 import com.linecorp.armeria.common.logging.RequestLog
 import com.linecorp.armeria.common.stream.ClosedStreamException
 import io.netty.handler.codec.http2.Http2Error
@@ -27,7 +26,7 @@ internal sealed class ProfiledError(
     object ConnectRefused : ProfiledError(latencyMetricRequired = true, typeMetricName = "connect_refused")
     object ConnectTimeout : ProfiledError(typeMetricName = "connect_timeout")
     object NoAvailableEndpoint : ProfiledError(typeMetricName = "no_available_endpoint")
-    object RequestClosedSession: ProfiledError(
+    object RequestClosedSession : ProfiledError(
         latencyMetricRequired = true,
         typeMetricName = "request_closed_session"
     )
@@ -63,12 +62,12 @@ internal sealed class ProfiledError(
     }
 }
 
-internal fun RequestLog.detectProfiledErrorIfAny(): ProfiledError? {
+internal fun RequestLog.detectProfiledErrorIfAny(isResponseStatusValid: (HttpStatus) -> Boolean): ProfiledError? {
     val requestCause = requestCause()
     val responseCause = responseCause()
     val status = responseHeaders().status()
     return when {
-        status.codeClass() != HttpStatusClass.SUCCESS && status != HttpStatus.UNKNOWN -> ProfiledError.InvalidStatus
+        !isResponseStatusValid(status) -> ProfiledError.InvalidStatus
         requestCause != null -> requestCause.unwrapUnprocessedExceptionIfNecessary().let {
             when (it) {
                 is ConnectException -> ProfiledError.ConnectRefused

--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledError.kt
@@ -67,7 +67,7 @@ internal fun RequestLog.detectProfiledErrorIfAny(isResponseStatusValid: (HttpSta
     val responseCause = responseCause()
     val status = responseHeaders().status()
     return when {
-        !isResponseStatusValid(status) -> ProfiledError.InvalidStatus
+        !isResponseStatusValid(status) && status != HttpStatus.UNKNOWN -> ProfiledError.InvalidStatus
         requestCause != null -> requestCause.unwrapUnprocessedExceptionIfNecessary().let {
             when (it) {
                 is ConnectException -> ProfiledError.ConnectRefused

--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClient.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClient.kt
@@ -175,8 +175,7 @@ class ProfiledHttpClient private constructor(
         @JvmStatic
         fun newDecorator(
             profiler: Profiler,
-            isResponseStatusValid: (HttpStatus) -> Boolean =
-                { it.codeClass() == HttpStatusClass.SUCCESS || it == HttpStatus.UNKNOWN }
+            isResponseStatusValid: (HttpStatus) -> Boolean = { it.codeClass() == HttpStatusClass.SUCCESS }
         ): Function<HttpClient, HttpClient> =
             Function {
                 ProfiledHttpClient(it, profiler, isResponseStatusValid)

--- a/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClient.kt
+++ b/jfix-armeria-aggregating-profiler/src/main/kotlin/ru/fix/armeria/aggregating/profiler/ProfiledHttpClient.kt
@@ -18,6 +18,10 @@ import ru.fix.armeria.commons.sessionProtocol
 import java.net.InetSocketAddress
 import java.util.function.Function
 
+/**
+ * @param isResponseStatusValid  It is guaranteed that input [HttpStatus] is not [HttpStatus.UNKNOWN]
+ * so that if this checking function is called then http response is received
+ */
 class ProfiledHttpClient private constructor(
     delegate: HttpClient,
     private val profiler: Profiler,
@@ -172,6 +176,10 @@ class ProfiledHttpClient private constructor(
 
         private data class ConnectProfiledCall(val profiledCall: ProfiledCall, val connectStartTimestamp: Long)
 
+        /**
+         * @param isResponseStatusValid  It is guaranteed that input [HttpStatus] is not [HttpStatus.UNKNOWN]
+         * so that if this checking function is called then http response is received
+         */
         @JvmStatic
         fun newDecorator(
             profiler: Profiler,


### PR DESCRIPTION
In case if non success response code is expected (302 or others), we should profile it as successful call.