### PR TITLE
Возможность задания готового Client Factory при создании клиента армерии

### DIFF
--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -1,5 +1,6 @@
 package ru.fix.armeria.facade.webclient
 
+import com.linecorp.armeria.client.ClientFactory
 import com.linecorp.armeria.client.ClientFactoryBuilder
 import com.linecorp.armeria.client.ClientOptionsBuilder
 import com.linecorp.armeria.client.endpoint.EndpointGroup
@@ -38,6 +39,7 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
     fun setDynamicEndpoint(
         addressProperty: DynamicProperty<SocketAddress>
     ): HttpClientBuilderT
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -45,6 +47,7 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
     fun setDynamicEndpoints(
         addressListProperty: DynamicProperty<List<SocketAddress>>
     ): HttpClientBuilderT
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -61,6 +64,11 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
         endpointGroup: EndpointGroup
     ): HttpClientBuilderT
 
+    /**
+     * ioThreadsCount - the number of event loop threads
+     * if argument [count] is passed, it will be used - otherwise used the default number of common worker group threads
+     * in [buildArmeriaWebClient]
+     */
     fun setIoThreadsCount(count: Int): HttpClientBuilderT
 
     fun setConnectTimeout(duration: Duration): HttpClientBuilderT
@@ -100,6 +108,11 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
 
     fun setSessionProtocol(sessionProtocol: SessionProtocol): HttpClientBuilderT
 
+    /**
+     * if argument [clientFactory] is passed, it will be used - otherwise it will build in method [buildArmeriaWebClient]
+     */
+    fun setClientFactory(clientFactory: ClientFactory): HttpClientBuilderT
+
     fun customizeArmeriaClientFactoryBuilder(
         customizer: ClientFactoryBuilder.() -> ClientFactoryBuilder
     ): HttpClientBuilderT
@@ -137,6 +150,7 @@ interface NotRetryingHttpClientBuilder : BaseHttpClientBuilder<NotRetryingHttpCl
     fun enableRequestsProfiling(profiler: Profiler): NotRetryingHttpClientBuilder
 
     fun setResponseTimeout(timeout: Duration): NotRetryingHttpClientBuilder
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -144,6 +158,7 @@ interface NotRetryingHttpClientBuilder : BaseHttpClientBuilder<NotRetryingHttpCl
     fun setResponseTimeout(timeoutProperty: DynamicProperty<Duration>): NotRetryingHttpClientBuilder
 
     fun setWriteRequestTimeout(timeout: Duration): NotRetryingHttpClientBuilder
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -170,6 +185,7 @@ interface BaseRetryingHttpClientBuilder<BuilderT : BaseRetryingHttpClientBuilder
     fun enableWholeRequestProfiling(profiler: Profiler): BuilderT
 
     fun setEachAttemptWriteRequestTimeout(timeout: Duration): BuilderT
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -195,6 +211,7 @@ interface TimeoutsConfiguringRetryingHttpClientBuilder :
     BaseRetryingHttpClientBuilder<TimeoutsConfiguringRetryingHttpClientBuilder> {
 
     fun setEachAttemptResponseTimeout(timeout: Duration): TimeoutsImmutableRetryingHttpClientBuilder
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -204,6 +221,7 @@ interface TimeoutsConfiguringRetryingHttpClientBuilder :
     ): TimeoutsImmutableRetryingHttpClientBuilder
 
     fun setWholeRequestTimeout(timeout: Duration): TimeoutsImmutableRetryingHttpClientBuilder
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.
@@ -214,6 +232,7 @@ interface TimeoutsConfiguringRetryingHttpClientBuilder :
         eachAttemptTimeout: Duration,
         wholeRequestTimeout: Duration
     ): TimeoutsImmutableRetryingHttpClientBuilder
+
     /**
      * [jfix-armeria-dynamic-request](https://github.com/ru-fix/jfix-armeria) dependency
      * OR Gradle capability _jfix-armeria-facade-dynamic-request-support_ required.

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/HttpClientBuilderApi.kt
@@ -66,8 +66,8 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
 
     /**
      * ioThreadsCount - the number of event loop threads
-     * if argument [count] is passed, it will be used - otherwise used the default number of common worker group threads
-     * in [buildArmeriaWebClient]
+     * if argument [count] is passed, it will be used - otherwise used [com.linecorp.armeria.common.Flags#numCommonWorkers]
+     * when calling [buildArmeriaWebClient]
      */
     fun setIoThreadsCount(count: Int): HttpClientBuilderT
 
@@ -109,7 +109,8 @@ interface BaseHttpClientBuilder<out HttpClientBuilderT : BaseHttpClientBuilder<H
     fun setSessionProtocol(sessionProtocol: SessionProtocol): HttpClientBuilderT
 
     /**
-     * if argument [clientFactory] is passed, it will be used - otherwise it will build in method [buildArmeriaWebClient]
+     * if argument [clientFactory] is passed, it will be used - otherwise new [ClientFactory] will be built when calling
+     * [buildArmeriaWebClient]
      */
     fun setClientFactory(clientFactory: ClientFactory): HttpClientBuilderT
 

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
@@ -159,8 +159,7 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
             else -> WebClient.builder()
         }
 
-        val clientFactory: ClientFactory
-        if (baseBuilderState.clientFactory == null) {
+        val clientFactory: ClientFactory = if (baseBuilderState.clientFactory == null) {
             // build ClientFactory
             var clientFactoryBuilder: ClientFactoryBuilder = baseBuilderState.clientFactoryBuilder()
             clientFactoryBuilder = clientFactoryBuilder.workerGroup(
@@ -171,12 +170,12 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
                 true
             )
             val clientFactoryBuilderCustomizer = baseBuilderState.clientFactoryBuilderCustomizer
-            clientFactory = clientFactoryBuilder
+            clientFactoryBuilder
                 .clientFactoryBuilderCustomizer()
                 .build()
         } else {
             // use passed ClientFactory
-            clientFactory = baseBuilderState.clientFactory
+            baseBuilderState.clientFactory
         }
 
 

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
@@ -1,6 +1,5 @@
 package ru.fix.armeria.facade.webclient.impl
 
-import ru.fix.armeria.facade.Either
 import com.linecorp.armeria.client.*
 import com.linecorp.armeria.client.endpoint.EndpointGroup
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy
@@ -14,6 +13,7 @@ import ru.fix.armeria.aggregating.profiler.ProfiledConnectionPoolListener
 import ru.fix.armeria.commons.AutoCloseableHttpClient
 import ru.fix.armeria.dynamic.request.endpoint.DynamicAddressEndpoints
 import ru.fix.armeria.dynamic.request.endpoint.SocketAddress
+import ru.fix.armeria.facade.Either
 import ru.fix.armeria.facade.retrofit.RetrofitHttpClientBuilder
 import ru.fix.armeria.facade.retrofit.impl.RetrofitHttpClientBuilderImpl
 import ru.fix.armeria.facade.webclient.BaseHttpClientBuilder
@@ -35,6 +35,7 @@ internal data class BaseHttpClientBuilderState(
         null
     },
     val ioThreadsCount: Int? = null,
+    val clientFactory: ClientFactory? = null,
     val clientFactoryBuilder: () -> ClientFactoryBuilder = { ClientFactory.builder() },
     val clientFactoryBuilderCustomizer: ClientFactoryBuilder.() -> ClientFactoryBuilder = { this },
     val clientOptionsBuilder: () -> ClientOptionsBuilder = { ClientOptions.builder() },
@@ -158,19 +159,25 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
             else -> WebClient.builder()
         }
 
-        // build ClientFactory
-        var clientFactoryBuilder: ClientFactoryBuilder = baseBuilderState.clientFactoryBuilder()
-        clientFactoryBuilder = clientFactoryBuilder.workerGroup(
-            EventLoopGroups.newEventLoopGroup(
-                baseBuilderState.ioThreadsCount ?: Flags.numCommonWorkers(),
-                "$clientName-eventloop"
-            ),
-            true
-        )
-        val clientFactoryBuilderCustomizer = baseBuilderState.clientFactoryBuilderCustomizer
-        val clientFactory = clientFactoryBuilder
-            .clientFactoryBuilderCustomizer()
-            .build()
+        val clientFactory: ClientFactory?
+        if (baseBuilderState.clientFactory == null) {
+            // build ClientFactory
+            var clientFactoryBuilder: ClientFactoryBuilder = baseBuilderState.clientFactoryBuilder()
+            clientFactoryBuilder = clientFactoryBuilder.workerGroup(
+                EventLoopGroups.newEventLoopGroup(
+                    baseBuilderState.ioThreadsCount ?: Flags.numCommonWorkers(),
+                    "$clientName-eventloop"
+                ),
+                true
+            )
+            val clientFactoryBuilderCustomizer = baseBuilderState.clientFactoryBuilderCustomizer
+            clientFactory = clientFactoryBuilder
+                .clientFactoryBuilderCustomizer()
+                .build()
+        } else {
+            // use passed ClientFactory
+            clientFactory = baseBuilderState.clientFactory
+        }
 
 
         // build ClientOptions
@@ -234,6 +241,10 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
 
     override fun setSessionProtocol(sessionProtocol: SessionProtocol): HttpClientBuilderT = copyOfThisBuilder(
         baseBuilderState.copy(sessionProtocol = sessionProtocol)
+    )
+
+    override fun setClientFactory(clientFactory: ClientFactory): HttpClientBuilderT = copyOfThisBuilder(
+        baseBuilderState.copy(clientFactory = clientFactory)
     )
 
     override fun customizeArmeriaClientFactoryBuilder(

--- a/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
+++ b/jfix-armeria-facade/src/main/kotlin/ru/fix/armeria/facade/webclient/impl/BaseHttpClientBuilderImpl.kt
@@ -159,7 +159,7 @@ internal abstract class BaseHttpClientBuilderImpl<out HttpClientBuilderT : BaseH
             else -> WebClient.builder()
         }
 
-        val clientFactory: ClientFactory?
+        val clientFactory: ClientFactory
         if (baseBuilderState.clientFactory == null) {
             // build ClientFactory
             var clientFactoryBuilder: ClientFactoryBuilder = baseBuilderState.clientFactoryBuilder()


### PR DESCRIPTION
расширила АПИ ru.fix.armeria.facade.webclient.BaseHttpClientBuilder чтобы можно было готовую ClientFactory указывать

идея в том, чтобы для тестов, там где это возможно указывать дефолтное клиент фактори, таким образом "возможно" получится сократить время остановки клиента армерии